### PR TITLE
SDD-616 add additional logging for azure b2c

### DIFF
--- a/NCS.DSS.ContentPushService.Tests/DigitalIdentityServiceTests.cs
+++ b/NCS.DSS.ContentPushService.Tests/DigitalIdentityServiceTests.cs
@@ -42,7 +42,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { CreateDigitalIdentity = true} ;
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -57,7 +57,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { CreateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
@@ -73,7 +73,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { CreateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
@@ -91,7 +91,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { DeleteDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -106,7 +106,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { DeleteDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
@@ -124,7 +124,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
@@ -140,7 +140,7 @@ namespace NCS.DSS.ContentPushService.Tests
         public async Task Generic_MessageNull_ReturnsCouldNotAction()
         {
             // Arrange
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
 
 
@@ -158,7 +158,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { UpdateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -173,7 +173,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { UpdateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -188,7 +188,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { UpdateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
@@ -206,7 +206,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { ChangeEmailAddress = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -221,7 +221,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { ChangeEmailAddress = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -236,7 +236,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { ChangeEmailAddress = true };
-            DigitalIdentityClient.Setup(x => x.Post( It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 

--- a/NCS.DSS.ContentPushService.Tests/DigitalIdentityServiceTests.cs
+++ b/NCS.DSS.ContentPushService.Tests/DigitalIdentityServiceTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NCS.DSS.ContentPushService.Constants;
-using NCS.DSS.ContentPushService.Listeners;
 using NCS.DSS.ContentPushService.Models;
 using NCS.DSS.ContentPushService.Services;
 using NCS.DSS.ContentPushService.Utils;
@@ -18,25 +17,24 @@ namespace NCS.DSS.ContentPushService.Tests
         private IDigitialIdentityService DigitalIdentityService;
         private Mock<IDigitalIdentityClient> DigitalIdentityClient;
         private Mock<IRequeueService> RequeueService;
-        private Mock<ILogger> _logger;
+        private Mock<ILogger<DigitialIdentityService>> _logger;
         private Mock<IMessageReceiverService> MessageReceiver;
 
         [SetUp]
         public void Setup()
         {
-            _logger = new Mock<ILogger>();
+            _logger = new Mock<ILogger<DigitialIdentityService>>();
             RequeueService = new Mock<IRequeueService>();
             DigitalIdentityClient = new Mock<IDigitalIdentityClient>();
-            DigitalIdentityService = new DigitialIdentityService(RequeueService.Object,  DigitalIdentityClient.Object);
+            DigitalIdentityService = new DigitialIdentityService(RequeueService.Object,  DigitalIdentityClient.Object, _logger.Object);
             MessageReceiver = new Mock<IMessageReceiverService>();
-            DigitalIdentityService = new DigitialIdentityService(RequeueService.Object, DigitalIdentityClient.Object);
 
         }
 
         #region Create Digital Identity
         private async Task<DigitalIdentityServiceActions> SendMessage( Message request)
         {
-            return await DigitalIdentityService.SendMessage("", request, MessageReceiver.Object, _logger.Object);
+            return await DigitalIdentityService.SendMessage("", request, MessageReceiver.Object);
         }
 
         [Test]
@@ -44,7 +42,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { CreateDigitalIdentity = true} ;
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -59,8 +57,8 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { CreateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<DigitalIdentity>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
              // Act
@@ -75,8 +73,8 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { CreateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -93,7 +91,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { DeleteDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -108,8 +106,8 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { DeleteDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Delete(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -126,8 +124,8 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
 
@@ -142,8 +140,8 @@ namespace NCS.DSS.ContentPushService.Tests
         public async Task Generic_MessageNull_ReturnsCouldNotAction()
         {
             // Arrange
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(false));
 
 
             // Act
@@ -160,7 +158,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { UpdateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -175,7 +173,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { UpdateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Put(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -190,8 +188,8 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { UpdateDigitalIdentity = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<DigitalIdentity>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -208,7 +206,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { ChangeEmailAddress = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -223,7 +221,7 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { ChangeEmailAddress = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<object>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
             var msg = new Message(System.Text.Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act
@@ -238,8 +236,8 @@ namespace NCS.DSS.ContentPushService.Tests
         {
             // Arrange
             var identity = new DigitalIdentity() { ChangeEmailAddress = true };
-            DigitalIdentityClient.Setup(x => x.Post(It.IsAny<DigitalIdentity>(), It.IsAny<string>())).Returns(Task.FromResult(false));
-            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>(), It.IsAny<ILogger>())).Returns(Task.FromResult(true));
+            DigitalIdentityClient.Setup(x => x.Post( It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(false));
+            RequeueService.Setup(x => x.RequeueItem(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<Message>())).Returns(Task.FromResult(true));
             var msg = new Message(System.Text.Encoding.Default.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(identity)));
 
             // Act

--- a/NCS.DSS.ContentPushService/Listeners/DigitalIdentityTopicListener.cs
+++ b/NCS.DSS.ContentPushService/Listeners/DigitalIdentityTopicListener.cs
@@ -25,7 +25,7 @@ namespace NCS.DSS.ContentPushService.Listeners
         {
             var service = new MessageReceiverService(messageReceiver);
             log.LogInformation("DigitalIdentityTopicListener received received message");
-            await _digitalidentity.SendMessage(TopicName,  serviceBusMessage, service, log);
+            await _digitalidentity.SendMessage(TopicName,  serviceBusMessage, service);
         }
     }
 }

--- a/NCS.DSS.ContentPushService/PushService/MessagePushService.cs
+++ b/NCS.DSS.ContentPushService/PushService/MessagePushService.cs
@@ -37,7 +37,15 @@ namespace NCS.DSS.ContentPushService.PushService
             if ((appIdUri == null) || (AppIdUri == ""))
                 throw new Exception("AppIdUri: " + AppIdUri + " does not exist!");
 
-            var bearerToken = await AuthenticationHelper.GetAccessToken(appIdUri);
+            var bearerToken = "";
+            try
+            {
+                bearerToken = await AuthenticationHelper.GetAccessToken(appIdUri);
+            } catch(Exception e)
+            {
+                log.LogInformation("Untable to get Access Token");
+                return;
+            }
 
             string clientUrl = Environment.GetEnvironmentVariable(ClientUrl).ToString();
             if ((clientUrl == null) || (ClientUrl == ""))

--- a/NCS.DSS.ContentPushService/PushService/MessagePushService.cs
+++ b/NCS.DSS.ContentPushService/PushService/MessagePushService.cs
@@ -28,10 +28,6 @@ namespace NCS.DSS.ContentPushService.PushService
                 return;
             }
 
-            var body1 = Encoding.UTF8.GetString(message.Body);
-            var customer1 = JsonConvert.DeserializeObject<MessageModel>(body1);
-
-
             string appIdUri = Environment.GetEnvironmentVariable(AppIdUri).ToString();
             if ((appIdUri == null) || (AppIdUri == ""))
                 throw new Exception("AppIdUri: " + AppIdUri + " does not exist!");

--- a/NCS.DSS.ContentPushService/PushService/MessagePushService.cs
+++ b/NCS.DSS.ContentPushService/PushService/MessagePushService.cs
@@ -18,7 +18,6 @@ namespace NCS.DSS.ContentPushService.PushService
     {
         readonly string _connectionString = Environment.GetEnvironmentVariable("ServiceBusConnectionString");
 
-        
         public async Task PushToTouchpoint(string AppIdUri, string ClientUrl, Message message, string TopicName, 
             MessageReceiver messageReceiver, ILogger log)
         {
@@ -41,10 +40,10 @@ namespace NCS.DSS.ContentPushService.PushService
             try
             {
                 bearerToken = await AuthenticationHelper.GetAccessToken(appIdUri);
-            } catch(Exception e)
+            }
+            catch (Exception e)
             {
-                log.LogInformation("Untable to get Access Token");
-                return;
+                log.LogWarning("Unable to get Access Token");
             }
 
             string clientUrl = Environment.GetEnvironmentVariable(ClientUrl).ToString();
@@ -107,10 +106,6 @@ namespace NCS.DSS.ContentPushService.PushService
                 log.LogError(string.Format("Error when attempting to post to clientUrl {0}", clientUrl));
                 throw;
             }
-
-            //For testing purposes
-            //response.StatusCode = HttpStatusCode.BadRequest;
-            //
 
             if (response?.StatusCode == HttpStatusCode.OK || response?.StatusCode == HttpStatusCode.Created || response?.StatusCode == HttpStatusCode.Accepted)
             {

--- a/NCS.DSS.ContentPushService/Services/DigitialIdentityService.cs
+++ b/NCS.DSS.ContentPushService/Services/DigitialIdentityService.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.Extensions.Logging;
 using NCS.DSS.ContentPushService.Constants;
 using NCS.DSS.ContentPushService.Models;
@@ -15,19 +14,21 @@ namespace NCS.DSS.ContentPushService.Services
     {
         private readonly IRequeueService _requeueService;
         private readonly IDigitalIdentityClient _digitalidentityClient;
+        private readonly ILogger<DigitialIdentityService> _logger;
 
-        public DigitialIdentityService(IRequeueService requeue, IDigitalIdentityClient digitalidentityclient)
+        public DigitialIdentityService(IRequeueService requeue, IDigitalIdentityClient digitalidentityclient, ILogger<DigitialIdentityService> logger)
         {
             _requeueService = requeue;
             _digitalidentityClient = digitalidentityclient;
+            _logger = logger;
         }
 
-        public async Task<DigitalIdentityServiceActions> SendMessage(string topic, Message message, IMessageReceiverService messageReceiver, ILogger logger)
+        public async Task<DigitalIdentityServiceActions> SendMessage(string topic, Message message, IMessageReceiverService messageReceiver)
         {
 
             if (message == null)
             {
-                logger.LogInformation("Digital Identity message is null, unable to post message");
+                _logger.LogInformation("Digital Identity message is null, unable to post message");
                 return DigitalIdentityServiceActions.CouldNotAction;
             }
 
@@ -65,18 +66,18 @@ namespace NCS.DSS.ContentPushService.Services
                 //if actioned message successfully, then remove message from queue
                 if (successfullyActioned)
                 {
-                    logger.LogInformation($"Successfully actioned CustomerId:{digitalidentity.CustomerGuid} - Create: { digitalidentity.CreateDigitalIdentity}, Delete:{digitalidentity.DeleteDigitalIdentity}, ChangeEmail: {digitalidentity.ChangeEmailAddress}");
+                    _logger.LogInformation($"Successfully actioned CustomerId:{digitalidentity.CustomerGuid} - Create: { digitalidentity.CreateDigitalIdentity}, Delete:{digitalidentity.DeleteDigitalIdentity}, ChangeEmail: {digitalidentity.ChangeEmailAddress}");
                     await messageReceiver.CompleteAsync(token);
                     return DigitalIdentityServiceActions.SuccessfullyActioned;
                 }
                 else
                 {
                     //requeue message on topic if message was not successfully actioned
-                    var retry = await _requeueService.RequeueItem(topic, 12, message, logger);
+                    var retry = await _requeueService.RequeueItem(topic, 12, message);
                     if (!retry)
                     {
                         await messageReceiver.DeadLetterAsync(token, "MaxTriesExceeded", "Attempted to send notification to Endpoint 12 times & failed!");
-                        logger.LogInformation($"CustomerId:{digitalidentity.CustomerGuid} - message:{message.MessageId} has been deadlettered after 12 attempts");
+                        _logger.LogInformation($"CustomerId:{digitalidentity.CustomerGuid} - message:{message.MessageId} has been deadlettered after 12 attempts");
                         return DigitalIdentityServiceActions.DeadLettered;
                     }
                     else
@@ -87,7 +88,7 @@ namespace NCS.DSS.ContentPushService.Services
             }
             else
             {
-                logger.LogInformation($"{message.MessageId} could not deserialize DigitalIdentity from message");
+                _logger.LogInformation($"{message.MessageId} could not deserialize DigitalIdentity from message");
                 return DigitalIdentityServiceActions.CouldNotAction;
             }
         }
@@ -95,24 +96,27 @@ namespace NCS.DSS.ContentPushService.Services
         private async Task<bool> ChangeEmail(DigitalIdentity digitalidentity)
         {
             var di = new { ObjectID = digitalidentity.IdentityStoreId, digitalidentity.NewEmail, digitalidentity.CurrentEmail };
-            return await _digitalidentityClient.Post(di, "ChangeEmail");
+            var jsonobj = JsonConvert.SerializeObject(di);
+            return await _digitalidentityClient.Post(jsonobj, "ChangeEmail");
         }
 
         private async Task<bool> UpdateUser(DigitalIdentity digitalidentity)
         {
             var di = new { ObjectId = digitalidentity.IdentityStoreId, FirstName = digitalidentity.FirstName, LastName = digitalidentity.LastName };
-            return await _digitalidentityClient.Put(di, "UpdateUser");
+            var jsonobj = JsonConvert.SerializeObject(di);
+            return await _digitalidentityClient.Put(jsonobj, "UpdateUser");
         }
 
         private async Task<bool> CreateNewDigitalIdentity(DigitalIdentity digitalidentity)
         {
             var di = new { givenName = digitalidentity.FirstName, lastName = digitalidentity.LastName, email = digitalidentity.EmailAddress, CustomerId = digitalidentity.CustomerGuid };
-            return await _digitalidentityClient.Post(di, "SignUpInvitation");
+            var jsonobj = JsonConvert.SerializeObject(di);
+            return await _digitalidentityClient.Post(jsonobj, "SignUpInvitation");
         }
 
         private async Task<bool> DeleteDigitalIdentity(DigitalIdentity digitalidentity)
         {
-            return await _digitalidentityClient.Delete(new { }, $"DeleteUser?id={digitalidentity.IdentityStoreId}");
+            return await _digitalidentityClient.Delete("", $"DeleteUser?id={digitalidentity.IdentityStoreId}");
         }
 
         private string GetLockToken(Message msg)

--- a/NCS.DSS.ContentPushService/Services/DigitialIdentityService.cs
+++ b/NCS.DSS.ContentPushService/Services/DigitialIdentityService.cs
@@ -97,26 +97,26 @@ namespace NCS.DSS.ContentPushService.Services
         {
             var di = new { ObjectID = digitalidentity.IdentityStoreId, digitalidentity.NewEmail, digitalidentity.CurrentEmail };
             var jsonobj = JsonConvert.SerializeObject(di);
-            return await _digitalidentityClient.Post(jsonobj, "ChangeEmail");
+            return await _digitalidentityClient.Post(digitalidentity.CustomerGuid?.ToString(), digitalidentity.IdentityStoreId?.ToString(), jsonobj, "ChangeEmail");
         }
 
         private async Task<bool> UpdateUser(DigitalIdentity digitalidentity)
         {
             var di = new { ObjectId = digitalidentity.IdentityStoreId, FirstName = digitalidentity.FirstName, LastName = digitalidentity.LastName };
             var jsonobj = JsonConvert.SerializeObject(di);
-            return await _digitalidentityClient.Put(jsonobj, "UpdateUser");
+            return await _digitalidentityClient.Put(digitalidentity.CustomerGuid?.ToString(), digitalidentity.IdentityStoreId?.ToString(), jsonobj, "UpdateUser");
         }
 
         private async Task<bool> CreateNewDigitalIdentity(DigitalIdentity digitalidentity)
         {
             var di = new { givenName = digitalidentity.FirstName, lastName = digitalidentity.LastName, email = digitalidentity.EmailAddress, CustomerId = digitalidentity.CustomerGuid };
             var jsonobj = JsonConvert.SerializeObject(di);
-            return await _digitalidentityClient.Post(jsonobj, "SignUpInvitation");
+            return await _digitalidentityClient.Post(digitalidentity.CustomerGuid?.ToString(), digitalidentity.IdentityStoreId?.ToString(), jsonobj, "SignUpInvitation");
         }
 
         private async Task<bool> DeleteDigitalIdentity(DigitalIdentity digitalidentity)
         {
-            return await _digitalidentityClient.Delete("", $"DeleteUser?id={digitalidentity.IdentityStoreId}");
+            return await _digitalidentityClient.Delete(digitalidentity.CustomerGuid?.ToString(), digitalidentity.IdentityStoreId?.ToString(),"", $"DeleteUser?id={digitalidentity.IdentityStoreId}");
         }
 
         private string GetLockToken(Message msg)

--- a/NCS.DSS.ContentPushService/Services/IDigitialIdentityService.cs
+++ b/NCS.DSS.ContentPushService/Services/IDigitialIdentityService.cs
@@ -1,14 +1,11 @@
 ﻿using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Core;
-using Microsoft.Extensions.Logging;
 using NCS.DSS.ContentPushService.Constants;
-using NCS.DSS.ContentPushService.Models;
 using System.Threading.Tasks;
 
 namespace NCS.DSS.ContentPushService.Services
 {
     public interface IDigitialIdentityService
     {
-        Task<DigitalIdentityServiceActions> SendMessage(string topic, Message message, IMessageReceiverService messageReceiver, ILogger logger);
+        Task<DigitalIdentityServiceActions> SendMessage(string topic, Message message, IMessageReceiverService messageReceiver);
     }
 }

--- a/NCS.DSS.ContentPushService/Services/IRequeueService.cs
+++ b/NCS.DSS.ContentPushService/Services/IRequeueService.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.Azure.ServiceBus;
-using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
 namespace NCS.DSS.ContentPushService.Services
 {
     public interface IRequeueService
     {
-        Task<bool> RequeueItem(string topicName, int maxRetryCount, Message message, ILogger logger);
+        Task<bool> RequeueItem(string topicName, int maxRetryCount, Message message);
     }
 }

--- a/NCS.DSS.ContentPushService/StartUp.cs
+++ b/NCS.DSS.ContentPushService/StartUp.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
 using NCS.DSS.ContentPushService;
 using NCS.DSS.ContentPushService.Listeners;
 using NCS.DSS.ContentPushService.PushService;
@@ -21,6 +23,10 @@ namespace NCS.DSS.ContentPushService
 
         private void ConfigureServices(IServiceCollection services)
         {
+            services.AddLogging(log =>
+            {
+                log.SetMinimumLevel(LogLevel.Trace);
+            });
             services.AddTransient<IListenersHelper, ListenersHelper>();
             services.AddTransient<IMessagePushService, MessagePushService>();
             services.AddTransient<IDigitialIdentityService, DigitialIdentityService>();

--- a/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,54 +21,73 @@ namespace NCS.DSS.ContentPushService.Utils
         public async Task<bool> Post(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Post, endpoint, body);
-            var respstr = await response.Content.ReadAsStringAsync();
-            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            var respstr = await GetResponseContent(response);
+            var isSuccess = IsSuccessfulResponse(response, HttpStatusCode.OK);
             if (!isSuccess)
-                _logger.LogInformation($"Failed to post customerId: {customerId}, ObjectId: {objectId} - Status: {response.StatusCode} response is: {respstr} ");
+                _logger.LogInformation($"Failed to post customerId: {customerId}, ObjectId: {objectId} - Status: {response?.StatusCode} response is: {respstr} ");
             return isSuccess;
         }
 
         public async Task<bool> Patch(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Patch, endpoint, body);
-            var respstr = await response.Content.ReadAsStringAsync();
-            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            var respstr = await GetResponseContent(response);
+            var isSuccess = IsSuccessfulResponse(response, HttpStatusCode.OK);
             if (!isSuccess)
-                _logger.LogInformation($"Failed to Patch json {body} - Status: {response.StatusCode}  response is: {respstr} ");
+                _logger.LogInformation($"Failed to Patch json {body} - Status: {response?.StatusCode}  response is: {respstr} ");
             return isSuccess;
         }
 
         public async Task<bool> Delete(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Delete, endpoint, body);
-            var respstr = await response.Content.ReadAsStringAsync();
-            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            var respstr = await GetResponseContent(response);
+            var isSuccess = IsSuccessfulResponse(response, HttpStatusCode.OK);
             if (!isSuccess)
-                _logger.LogInformation($"Failed to delete customerId: {customerId}, objectId: {objectId} - Status: {response.StatusCode}  response is : {respstr} ");
+                _logger.LogInformation($"Failed to delete customerId: {customerId}, objectId: {objectId} - Status: {response?.StatusCode}  response is : {respstr} ");
             return isSuccess;
         }
 
         public async Task<bool> Put(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Put, endpoint, body);
-            var respstr = await response.Content.ReadAsStringAsync();
-            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            var respstr = await GetResponseContent(response);
+            var isSuccess = IsSuccessfulResponse(response, HttpStatusCode.OK);
             if (!isSuccess)
-                _logger.LogInformation($"Failed to put customerId: {customerId}, objectId: {objectId} - Status: {response.StatusCode}  response is : {respstr} ");
+                _logger.LogInformation($"Failed to put customerId: {customerId}, objectId: {objectId} - Status: {response?.StatusCode}  response is : {respstr} ");
             return isSuccess;
         }
 
-        private async  Task<HttpResponseMessage> Send(HttpMethod verb, string endpoint, string body)
+        private async Task<HttpResponseMessage> Send(HttpMethod verb, string endpoint, string body)
         {
-            using (var client = _httpclientFactory.CreateClient("AzureB2C"))
-            using (var request = new HttpRequestMessage(verb, endpoint))
+            try
             {
-                using (var stringContent = new StringContent(body, Encoding.UTF8, "application/json"))
+                using (var client = _httpclientFactory.CreateClient("AzureB2C"))
+                using (var request = new HttpRequestMessage(verb, endpoint))
                 {
-                    request.Content = stringContent;
-                    return await client.SendAsync(request);
+                    using (var stringContent = new StringContent(body, Encoding.UTF8, "application/json"))
+                    {
+                        request.Content = stringContent;
+                        return await client.SendAsync(request);
+                    }
                 }
+            } catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
             }
+            return null;
+        }
+
+        private bool IsSuccessfulResponse(HttpResponseMessage resp, HttpStatusCode expectedResult)
+        {
+            return resp?.StatusCode == expectedResult;
+        }
+
+        private async Task<string> GetResponseContent(HttpResponseMessage resp)
+        {
+            if(resp != null)
+                return await resp.Content.ReadAsStringAsync();
+            return string.Empty;
         }
     }
 }

--- a/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
@@ -18,7 +18,7 @@ namespace NCS.DSS.ContentPushService.Utils
 
         public async Task<bool> Post(string body, string endpoint)
         {
-            var response = await Send(HttpMethod.Delete, endpoint, body);
+            var response = await Send(HttpMethod.Post, endpoint, body);
             var respstr = await response.Content.ReadAsStringAsync();
             var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
             if (!isSuccess)
@@ -28,7 +28,7 @@ namespace NCS.DSS.ContentPushService.Utils
 
         public async Task<bool> Patch(string body, string endpoint)
         {
-            var response = await Send(HttpMethod.Delete, endpoint, body);
+            var response = await Send(HttpMethod.Patch, endpoint, body);
             var respstr = await response.Content.ReadAsStringAsync();
             var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
             if (!isSuccess)

--- a/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -17,83 +16,55 @@ namespace NCS.DSS.ContentPushService.Utils
             _logger = logger;
         }
 
-        public async Task<bool> Post<T>(T t, string endpoint)
+        public async Task<bool> Post(string body, string endpoint)
         {
-            using (var client = _httpclientFactory.CreateClient("AzureB2C"))
-            using (var request = new HttpRequestMessage(HttpMethod.Post, endpoint))
-            {
-                var json = JsonConvert.SerializeObject(t);
-                using (var stringContent = new StringContent(json, Encoding.UTF8, "application/json"))
-                {
-                    request.Content = stringContent;
-                    using (var response = await client.SendAsync(request))
-                    {
-                        var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
-                        if (!isSuccess)
-                            _logger.LogInformation($"Failed to post json {json} - response is code is: {response.StatusCode} ");
-                        return isSuccess;
-
-                    }
-                }
-            }
+            var response = await Send(HttpMethod.Delete, endpoint, body);
+            var respstr = await response.Content.ReadAsStringAsync();
+            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            if (!isSuccess)
+                _logger.LogInformation($"Failed to post json {body} - Status: {response.StatusCode} response is: {respstr} ");
+            return isSuccess;
         }
 
-        public async Task<bool> Patch<T>(T t, string endpoint)
+        public async Task<bool> Patch(string body, string endpoint)
         {
-            using (var client = _httpclientFactory.CreateClient("AzureB2C"))
-            using (var request = new HttpRequestMessage(HttpMethod.Patch, endpoint))
-            {
-                var json = JsonConvert.SerializeObject(t);
-                using (var stringContent = new StringContent(json, Encoding.UTF8, "application/json"))
-                {
-                    request.Content = stringContent;
-                    using (var response = await client.SendAsync(request))
-                    {
-                        var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
-                        if (!isSuccess)
-                            _logger.LogInformation($"Failed to patch json {json} - response is code is: {response.StatusCode} ");
-                        return isSuccess;
-                    }
-                }
-            }
+            var response = await Send(HttpMethod.Delete, endpoint, body);
+            var respstr = await response.Content.ReadAsStringAsync();
+            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            if (!isSuccess)
+                _logger.LogInformation($"Failed to Patch json {body} - Status: {response.StatusCode}  response is: {respstr} ");
+            return isSuccess;
         }
 
-        public async Task<bool> Delete<T>(T t, string endpoint)
+        public async Task<bool> Delete(string body, string endpoint)
         {
-            using (var client = _httpclientFactory.CreateClient("AzureB2C"))
-            using (var request = new HttpRequestMessage(HttpMethod.Delete, endpoint))
-            {
-                var json = JsonConvert.SerializeObject(t);
-                using (var stringContent = new StringContent(json, Encoding.UTF8, "application/json"))
-                {
-                    request.Content = stringContent;
-                    using (var response = await client.SendAsync(request))
-                    {
-                        var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
-                        if (!isSuccess)
-                            _logger.LogInformation($"Failed to delete json {json} - response is code is: {response.StatusCode} ");
-                        return isSuccess;
-                    }
-                }
-            }
+            var response = await Send(HttpMethod.Delete, endpoint, body);
+            var respstr = await response.Content.ReadAsStringAsync();
+            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            if (!isSuccess)
+                _logger.LogInformation($"Failed to delete json {body} - Status: {response.StatusCode}  response is : {respstr} ");
+            return isSuccess;
         }
 
-        public async Task<bool> Put<T>(T t, string endpoint)
+        public async Task<bool> Put(string body, string endpoint)
+        {
+            var response = await Send(HttpMethod.Put, endpoint, body);
+            var respstr = await response.Content.ReadAsStringAsync();
+            var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
+            if (!isSuccess)
+                _logger.LogInformation($"Failed to put json {body} - Status: {response.StatusCode}  response is : {respstr} ");
+            return isSuccess;
+        }
+
+        private async  Task<HttpResponseMessage> Send(HttpMethod verb, string endpoint, string body)
         {
             using (var client = _httpclientFactory.CreateClient("AzureB2C"))
-            using (var request = new HttpRequestMessage(HttpMethod.Put, endpoint))
+            using (var request = new HttpRequestMessage(verb, endpoint))
             {
-                var json = JsonConvert.SerializeObject(t);
-                using (var stringContent = new StringContent(json, Encoding.UTF8, "application/json"))
+                using (var stringContent = new StringContent(body, Encoding.UTF8, "application/json"))
                 {
                     request.Content = stringContent;
-                    using (var response = await client.SendAsync(request))
-                    {
-                        var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
-                        if (!isSuccess)
-                            _logger.LogInformation($"Failed to delete json {json} - response is code is: {response.StatusCode} ");
-                        return isSuccess;
-                    }
+                    return await client.SendAsync(request);
                 }
             }
         }

--- a/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/DigitalIdentityClient.cs
@@ -16,17 +16,17 @@ namespace NCS.DSS.ContentPushService.Utils
             _logger = logger;
         }
 
-        public async Task<bool> Post(string body, string endpoint)
+        public async Task<bool> Post(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Post, endpoint, body);
             var respstr = await response.Content.ReadAsStringAsync();
             var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
             if (!isSuccess)
-                _logger.LogInformation($"Failed to post json {body} - Status: {response.StatusCode} response is: {respstr} ");
+                _logger.LogInformation($"Failed to post customerId: {customerId}, ObjectId: {objectId} - Status: {response.StatusCode} response is: {respstr} ");
             return isSuccess;
         }
 
-        public async Task<bool> Patch(string body, string endpoint)
+        public async Task<bool> Patch(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Patch, endpoint, body);
             var respstr = await response.Content.ReadAsStringAsync();
@@ -36,23 +36,23 @@ namespace NCS.DSS.ContentPushService.Utils
             return isSuccess;
         }
 
-        public async Task<bool> Delete(string body, string endpoint)
+        public async Task<bool> Delete(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Delete, endpoint, body);
             var respstr = await response.Content.ReadAsStringAsync();
             var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
             if (!isSuccess)
-                _logger.LogInformation($"Failed to delete json {body} - Status: {response.StatusCode}  response is : {respstr} ");
+                _logger.LogInformation($"Failed to delete customerId: {customerId}, objectId: {objectId} - Status: {response.StatusCode}  response is : {respstr} ");
             return isSuccess;
         }
 
-        public async Task<bool> Put(string body, string endpoint)
+        public async Task<bool> Put(string customerId, string objectId, string body, string endpoint)
         {
             var response = await Send(HttpMethod.Put, endpoint, body);
             var respstr = await response.Content.ReadAsStringAsync();
             var isSuccess = response.StatusCode == System.Net.HttpStatusCode.OK;
             if (!isSuccess)
-                _logger.LogInformation($"Failed to put json {body} - Status: {response.StatusCode}  response is : {respstr} ");
+                _logger.LogInformation($"Failed to put customerId: {customerId}, objectId: {objectId} - Status: {response.StatusCode}  response is : {respstr} ");
             return isSuccess;
         }
 

--- a/NCS.DSS.ContentPushService/Utils/IDigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/IDigitalIdentityClient.cs
@@ -4,9 +4,9 @@ namespace NCS.DSS.ContentPushService.Utils
 {
     public interface IDigitalIdentityClient
     {
-        Task<bool> Post(string body, string endpoint);
-        Task<bool> Patch(string body, string endpoint);
-        Task<bool> Delete(string body, string endpoint);
-        Task<bool> Put(string body, string endpoint);
+        Task<bool> Post(string customerId, string objectId, string body, string endpoint);
+        Task<bool> Patch(string customerId, string objectId, string body, string endpoint);
+        Task<bool> Delete(string customerId, string objectId, string body, string endpoint);
+        Task<bool> Put(string customerId, string objectId, string body, string endpoint);
     }
 }

--- a/NCS.DSS.ContentPushService/Utils/IDigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/IDigitalIdentityClient.cs
@@ -4,9 +4,9 @@ namespace NCS.DSS.ContentPushService.Utils
 {
     public interface IDigitalIdentityClient
     {
-        Task<bool> Post<T>(T t, string endpoint);
-        Task<bool> Patch<T>(T t, string endpoint);
-        Task<bool> Delete<T>(T t, string endpoint);
-        Task<bool> Put<T>(T t, string endpoint);
+        Task<bool> Post(string body, string endpoint);
+        Task<bool> Patch(string body, string endpoint);
+        Task<bool> Delete(string body, string endpoint);
+        Task<bool> Put(string body, string endpoint);
     }
 }

--- a/NCS.DSS.ContentPushService/Utils/IDigitalIdentityClient.cs
+++ b/NCS.DSS.ContentPushService/Utils/IDigitalIdentityClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace NCS.DSS.ContentPushService.Utils
 {

--- a/NCS.DSS.ContentPushService/host.json
+++ b/NCS.DSS.ContentPushService/host.json
@@ -6,5 +6,10 @@
         "autoComplete": false
       }
     }
+  },
+  "logging": {
+    "logLevel": {
+      "NCS.DSS.ContentPushService": "Information"
+    }
   }
 }


### PR DESCRIPTION
This PR fixes logging failures when calling Azure b2c api and refactors the code that was duplicated in the client. It contains the following changes - 
- Inject ILogger into constructor
- Updated Unit Tests to inject ilogger
- Changes logging level to be information.
- Tidy up of DigitalIdentityService so that failures are logged.

